### PR TITLE
Added CDF4 support for siesta

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -48,6 +48,7 @@ class Siesta(MakefilePackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('scalapack', when='+mpi') # NOTE: cannot ld-link without scalapack when +mpi
+    depends_on('hdf5 +fortran +hl')
     depends_on('netcdf-c')
     depends_on('netcdf-fortran')
     depends_on('xmlf90', when='+psml')
@@ -94,7 +95,7 @@ class Siesta(MakefilePackage):
                                 'SCALAPACK_LIBS = {0}'.format(self.spec['scalapack'].libs.ld_flags))
 
             archmake.filter('^COMP_LIBS\s=.*',
-                            'COMP_LIBS = # Empty: BLAS and LAPACK are Spack dependencies.')
+                            'COMP_LIBS = libncdf.a libfdict.a')
 
             include_section_tag = '# Include_section:'
             include_mks = [include_section_tag]
@@ -131,8 +132,11 @@ class Siesta(MakefilePackage):
 
             incflags_plus = self.spec['netcdf-fortran'].headers.cpp_flags
             archmake.filter('^NETCDF_LIBS\s=.*',
-                            'NETCDF_LIBS = {0}'.format(
-                                self.spec['netcdf-fortran'].libs.ld_flags
+                            'NETCDF_LIBS = {} {} {} -lhdf5_fortran {}'.format(
+                                self.spec['netcdf-fortran'].libs.ld_flags,
+				self.spec['netcdf-c'].libs.ld_flags,
+				self.spec['hdf5'].libs.ld_flags,
+				self.spec['zlib'].libs.ld_flags
                             ))
 
             if '~mpi' in self.spec:
@@ -150,7 +154,7 @@ class Siesta(MakefilePackage):
             # fflags += ' ' + self.compiler.pic_flag
             # archmake.filter('^FFLAGS = .*', 'FFLAGS = ' + fflags)
 
-            fppflags = '-DGRID_DP -DCDF'
+            fppflags = '-DGRID_DP -DCDF -DNCDF -DNCDF_4'
             if '+mpi' in self.spec:
                 fppflags = '-DMPI {0}'.format(fppflags)
 


### PR DESCRIPTION
Hi Vladimir, with these changes CDF4 support is working (I tested it with tbtrans).

Two comments:
- I had to add the extra dependency `hdf5` specifying the `+fortran` variant. I don't know if adding the variant can be done through the `netcdf-c` dependency in some way that I don't know about. A weak point of what I did is that I needed to specify `+hl` since `netcdf-c` needs it and otherwise it showed an incompatibility. This is not optimal, because we would need to keep variants updated if `netcdf-c` changes its requirements.
- I don't know if you would like to make CDF4 support optional.

Also a doubt that has nothing to do with the PR: Why is `netcdf-c` a direct dependency instead of an indirect dependency through `netcdf-fortran`?